### PR TITLE
Fix latex comment

### DIFF
--- a/tabilize.ipynb
+++ b/tabilize.ipynb
@@ -134,9 +134,9 @@
     {
       "cell_type": "code",
       "source": [
-        "\\definecolor{tabfirst}{rgb}{1, 0.7, 0.7} # red\n",
-        "\\definecolor{tabsecond}{rgb}{1, 0.85, 0.7} # orange\n",
-        "\\definecolor{tabthird}{rgb}{1, 1, 0.7} # yellow\n",
+        "\\definecolor{tabfirst}{rgb}{1, 0.7, 0.7} % red\n",
+        "\\definecolor{tabsecond}{rgb}{1, 0.85, 0.7} % orange\n",
+        "\\definecolor{tabthird}{rgb}{1, 1, 0.7} % yellow\n",
         "\n",
         "\\begin{table}\n",
         "    \\centering\n",


### PR DESCRIPTION
Using % as the comment in latex to avoid latex compiler error.